### PR TITLE
add exporter/importer of 'bridgestream'

### DIFF
--- a/src/__tests__/bridgestream/__snapshots__/exporter.js.snap
+++ b/src/__tests__/bridgestream/__snapshots__/exporter.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic export 1`] = `
+Array [
+  "[4,0,\\"meta\\",1,\\"test\\",\\"0.0.0\\"]",
+  "[4,1,\\"account\\",\\"mock_account_export_0\\",\\"pQNKgto\\",141]",
+  "[4,2,\\"account\\",\\"mock_account_export_1\\",\\"2KTQvcmdW2zTneCnPImZvgYLGi5rIBgc\\",141]",
+  "[4,3,\\"account\\",\\"mock_account_export_2\\",\\"23PIvq83MrbdhquMsST6yH4PX3dBptsh\\",141]",
+]
+`;
+
+exports[`basic export with pad 1`] = `
+Array [
+  "[4,0,\\"meta\\",1,\\"test\\",\\"0.0.0\\"]                                                 ",
+  "[4,1,\\"account\\",\\"mock_account_export_0\\",\\"pQNKgto\\",141]                         ",
+  "[4,2,\\"account\\",\\"mock_account_export_1\\",\\"2KTQvcmdW2zTneCnPImZvgYLGi5rIBgc\\",141]",
+  "[4,3,\\"account\\",\\"mock_account_export_2\\",\\"23PIvq83MrbdhquMsST6yH4PX3dBptsh\\",141]",
+]
+`;

--- a/src/__tests__/bridgestream/__snapshots__/importer.js.snap
+++ b/src/__tests__/bridgestream/__snapshots__/importer.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import 1`] = `
+Object {
+  "accounts": Array [
+    Array [
+      "account",
+      "mock_account_export_0",
+      "pQNKgto",
+      141,
+    ],
+    Array [
+      "account",
+      "mock_account_export_1",
+      "2KTQvcmdW2zTneCnPImZvgYLGi5rIBgc",
+      141,
+    ],
+    Array [
+      "account",
+      "mock_account_export_2",
+      "23PIvq83MrbdhquMsST6yH4PX3dBptsh",
+      141,
+    ],
+  ],
+  "meta": Object {
+    "chunksFormatVersion": 1,
+    "exporterName": "test",
+    "exporterVersion": "0.0.0",
+  },
+}
+`;

--- a/src/__tests__/bridgestream/exporter.js
+++ b/src/__tests__/bridgestream/exporter.js
@@ -1,0 +1,31 @@
+// @flow
+import { getFiatUnit } from "@ledgerhq/currencies";
+import { makeChunks } from "../../bridgestream/exporter";
+import { genAccount } from "../../mock/account";
+
+test("basic export", () => {
+  const accounts = Array(3)
+    .fill(null)
+    .map((_, i) => genAccount("export_" + i));
+  const arg = {
+    accounts,
+    exporterName: "test",
+    exporterVersion: "0.0.0"
+  };
+  const chunks = makeChunks(arg);
+  expect(chunks).toMatchSnapshot();
+});
+
+test("basic export with pad", () => {
+  const accounts = Array(3)
+    .fill(null)
+    .map((_, i) => genAccount("export_" + i));
+  const arg = {
+    accounts,
+    exporterName: "test",
+    exporterVersion: "0.0.0",
+    pad: true
+  };
+  const chunks = makeChunks(arg);
+  expect(chunks).toMatchSnapshot();
+});

--- a/src/__tests__/bridgestream/importer.js
+++ b/src/__tests__/bridgestream/importer.js
@@ -1,0 +1,37 @@
+// @flow
+import { getFiatUnit } from "@ledgerhq/currencies";
+import { makeChunks } from "../../bridgestream/exporter";
+import {
+  parseChunksReducer,
+  areChunksComplete,
+  chunksToResult
+} from "../../bridgestream/importer";
+import { genAccount } from "../../mock/account";
+
+test("import", () => {
+  const accounts = Array(3)
+    .fill(null)
+    .map((_, i) => genAccount("export_" + i));
+  const arg = {
+    accounts,
+    exporterName: "test",
+    exporterVersion: "0.0.0"
+  };
+  const chunks = makeChunks(arg);
+
+  let data = [];
+  [1, 2, 0, 3].forEach((nb, i) => {
+    expect(areChunksComplete(data)).toBe(false);
+    data = parseChunksReducer(data, chunks[nb]);
+    expect(data.length).toBe(i + 1);
+    data = parseChunksReducer(data, chunks[nb]);
+    expect(data.length).toBe(i + 1); // chunk already existed
+  });
+  expect(areChunksComplete(data)).toBe(true);
+  const res = chunksToResult(data);
+  // $FlowFixMe
+  expect(res.accounts).toMatchObject(
+    accounts.map(a => ["account", a.id, a.name, a.currency.coinType])
+  );
+  expect(res).toMatchSnapshot();
+});

--- a/src/__tests__/helpers/countervalue.js
+++ b/src/__tests__/helpers/countervalue.js
@@ -36,8 +36,12 @@ test("makeCalculateCounterValue basic test", () => {
   );
 
   expect(reverse(calc(42))).toBe(42);
-  expect(reverse(calc(42, new Date(2017, 3, 14)), new Date(2017, 3, 14))).toBe(42);
-  expect(reverse(calc(42, new Date(2019, 3, 14)), new Date(2019, 3, 14))).toBe(42);
+  expect(reverse(calc(42, new Date(2017, 3, 14)), new Date(2017, 3, 14))).toBe(
+    42
+  );
+  expect(reverse(calc(42, new Date(2019, 3, 14)), new Date(2019, 3, 14))).toBe(
+    42
+  );
   expect(get(new Date(2017, 10, 14))).toBe(1091.4770484628843);
   expect(get(new Date(2019, 3, 14))).toBe(1);
   expect(get()).toBe(1);

--- a/src/bridgestream/README.md
+++ b/src/bridgestream/README.md
@@ -1,0 +1,44 @@
+# bridgestream
+
+bridgestream is a bridge that allow one-directional stream communication from one legder app to another.
+
+It currently allows to export Accounts from the desktop app to the mobile app.
+
+### Desktop code gist
+
+```js
+import { makeChunks } from "@ledgerhq/wallet-common/lib/bridgestream/exporter";
+const chunks = makeChunks({
+  accounts,
+  exporterName: "desktop",
+  exporterVersion: "0.0.0"
+});
+// loop for each chunk of chunks[i]: display chunk QRCode, sleep a bit of time
+```
+
+### Mobile code gist
+
+```js
+import {
+  parseChunkR, areChunksComplete, chunksToResult
+} from "@ledgerhq/wallet-common/lib/bridgestream/importer";
+
+class Scanning extends Component<{
+  onResult: Result => void
+}> {
+  lastData: ?string = null;
+  chunks: Data[] = [];
+  completed: boolean = false;
+  onBarCodeRead = ({ data }: { data: string }) => {
+    if (data && data !== this.lastData && !this.completed) {
+      this.lastData = data;
+      this.chunks = parseChunksReducer(this.chunks, data);
+      if (areChunksComplete(this.chunks)) {
+        this.completed = true;
+        this.props.onResult(chunksToResult(this.chunks));
+      }
+    }
+  };
+
+  ...
+```

--- a/src/bridgestream/exporter.js
+++ b/src/bridgestream/exporter.js
@@ -1,0 +1,41 @@
+// @flow
+import type { Account } from "../types/account";
+
+export type DataIn = {
+  // accounts to export (filter them to only be the visible ones)
+  accounts: Account[],
+  // the name of the exporter. e.g. "desktop" for the desktop app
+  exporterName: string,
+  // the version of the exporter. e.g. the desktop app version
+  exporterVersion: string,
+  // enable a mode that will add empty space to make all chunks of same size. to makes QR code of same dimension
+  pad?: boolean
+};
+
+/**
+ * export data into a chunk of string
+ * @memberof bridgestream/exporter
+ */
+export function makeChunks({
+  accounts,
+  exporterName,
+  exporterVersion,
+  pad
+}: DataIn): string[] {
+  const chunksFormatVersion = 1;
+  const data = [
+    ["meta", chunksFormatVersion, exporterName, exporterVersion],
+    ...accounts.map(account => [
+      "account",
+      account.id,
+      account.name,
+      account.currency.coinType
+    ])
+  ];
+  let r = data.map((arr, i) => JSON.stringify([data.length, i, ...arr]));
+  if (pad) {
+    const max = r.reduce((max, s) => Math.max(max, s.length), 0);
+    r = r.map(s => s.padEnd(max));
+  }
+  return r;
+}

--- a/src/bridgestream/importer.js
+++ b/src/bridgestream/importer.js
@@ -1,0 +1,89 @@
+// @flow
+
+export type Data = Array<mixed>;
+export type AccountData = ["account", string, string, number];
+export type Result = {
+  accounts: AccountData[],
+  meta: {
+    chunksFormatVersion: number,
+    exporterName: string,
+    exporterVersion: string
+  }
+};
+
+/**
+ * reduce chunks data array to add on more chunk to it
+ * @memberof bridgestream/importer
+ */
+export function parseChunksReducer(chunks: Data[], chunk: string): Data[] {
+  try {
+    const data: mixed = JSON.parse(chunk);
+    if (!Array.isArray(data)) throw new Error("not an array");
+    const [dataLength, index, type] = data;
+    if (typeof dataLength !== "number" || dataLength <= 0) {
+      throw new Error("invalid dataLength");
+    }
+    if (typeof index !== "number" || index < 0 || index >= dataLength) {
+      throw new Error("invalid index");
+    }
+    if (typeof type !== "string" || !type) {
+      throw new Error("invalid type");
+    }
+    if (chunks.length > 0 && data[0] !== chunks[0][0]) {
+      throw new Error("different dataLength");
+    }
+    if (chunks.some(c => c[1] === index)) {
+      // chunk already exists. we are just ignoring
+      return chunks;
+    }
+    return chunks.concat([data]);
+  } catch (e) {
+    console.warn(`Invalid chunk ${e.message}. Got: ${chunk}`);
+    return chunks;
+  }
+}
+
+/**
+ * check if the chunks have all been retrieved
+ * @memberof bridgestream/importer
+ */
+export const areChunksComplete = (chunks: Data[]): boolean =>
+  chunks.length > 0 && chunks[0][0] === chunks.length;
+
+/**
+ * return final result of the chunks. assuming you have checked `areChunksComplete`
+ * @memberof bridgestream/importer
+ */
+export function chunksToResult(rawChunks: Data[]): Result {
+  const chunks = rawChunks
+    .sort((a, b) => Number(a[1]) - Number(b[1]))
+    .map(chunk => chunk.slice(2));
+  const accounts = [];
+  let meta;
+  for (const d of chunks) {
+    const [type] = d;
+    if (type === "meta") {
+      const [, chunksFormatVersion, exporterName, exporterVersion] = d;
+      if (
+        typeof chunksFormatVersion === "number" &&
+        typeof exporterName === "string" &&
+        typeof exporterVersion === "string"
+      ) {
+        meta = { chunksFormatVersion, exporterName, exporterVersion };
+      }
+    } else if (type === "account") {
+      const [, id, name, coinType] = d;
+      if (
+        typeof id === "string" &&
+        typeof name === "string" &&
+        typeof coinType === "number"
+      ) {
+        accounts.push([type, id, name, coinType]);
+      }
+    }
+  }
+  if (!meta) {
+    throw new Error("meta chunk not found");
+  }
+  return { accounts, meta };
+}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -52,6 +52,10 @@ export type BalanceHistory = Array<{ date: Date, value: number }>;
  * if Date is falsy, the current "latest" price is to be returned.
  * the value 0 or any falsy returned value is means the countervalue is not available.
  * It it up to GetPairHistory implementation to chose the date granularity to use.
+ * NB Ideally a get pair history implementation should fallback on 0 if before the timerange he knows, or "latest" after the timerange it knows
+@example
+<any date before>    2018-03-01  2018-03-02  2018-03-03  <any date after>
+0 0 0 0 0 0 0 0 0       9.65         9.22      8.77      latest latest latest ...
  */
 export type GetPairHistory = (
   coinTicker: string,


### PR DESCRIPTION
# bridgestream

bridgestream is a bridge that allow one-directional stream communication from one legder app to another.

It currently allows to export Accounts from the desktop app to the mobile app.

### Desktop code gist

```js
import { makeChunks } from "@ledgerhq/wallet-common/lib/bridgestream/exporter";
const chunks = makeChunks({
  accounts,
  exporterName: "desktop",
  exporterVersion: "0.0.0"
});
// loop for each chunk of chunks[i]: display chunk QRCode, sleep a bit of time
```

### Mobile code gist

```js
import {
  parseChunkR, areChunksComplete, chunksToResult
} from "@ledgerhq/wallet-common/lib/bridgestream/importer";

class Scanning extends Component<{
  onResult: Result => void
}> {
  lastData: ?string = null;
  chunks: Data[] = [];
  completed: boolean = false;
  onBarCodeRead = ({ data }: { data: string }) => {
    if (data && data !== this.lastData && !this.completed) {
      this.lastData = data;
      this.chunks = parseChunksReducer(this.chunks, data);
      if (areChunksComplete(this.chunks)) {
        this.completed = true;
        this.props.onResult(chunksToResult(this.chunks));
      }
    }
  };

  ...
```
