### PR TITLE
refactoring / allow rounding in countervalue calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # ledger-wallet-common
+
 Common ground for the Ledger Wallet apps

--- a/src/__tests__/api/countervalue.js
+++ b/src/__tests__/api/countervalue.js
@@ -1,13 +1,9 @@
 // @flow
 import { getCurrencyByCoinType, getFiatUnit } from "@ledgerhq/currencies";
-import {
-  fetchCurrentCounterValues,
-  fetchHistodayCounterValues,
-  fetchHistodayCounterValuesMultiple
-} from "../../api/countervalue";
+import { fetchCurrentRates, fetchHistodayRates } from "../../api/countervalue";
 
-test("fetchCurrentCounterValues", async () => {
-  const res = await fetchCurrentCounterValues(
+test("fetchCurrentRates", async () => {
+  const res = await fetchCurrentRates(
     [getCurrencyByCoinType(0), getCurrencyByCoinType(2)],
     getFiatUnit("EUR")
   );
@@ -17,8 +13,8 @@ test("fetchCurrentCounterValues", async () => {
   expect(res.LTC.EUR.latest).toBeGreaterThan(0);
 });
 
-test("fetchHistodayCounterValues", async () => {
-  const res = await fetchHistodayCounterValues(
+test("fetchHistodayRates", async () => {
+  const res = await fetchHistodayRates(
     getCurrencyByCoinType(0),
     getFiatUnit("USD")
   );
@@ -26,8 +22,8 @@ test("fetchHistodayCounterValues", async () => {
   expect(Object.keys(res).length).toBeGreaterThan(100);
 });
 
-test("fetchHistodayCounterValuesMultiple", async () => {
-  const res = await fetchHistodayCounterValuesMultiple(
+test("fetchHistodayRates with multiple currencies", async () => {
+  const res = await fetchHistodayRates(
     [getCurrencyByCoinType(0), getCurrencyByCoinType(2)],
     getFiatUnit("USD")
   );

--- a/src/__tests__/helpers/countervalue.js
+++ b/src/__tests__/helpers/countervalue.js
@@ -4,8 +4,13 @@ import { getFiatUnit, getCurrencyByCoinType } from "@ledgerhq/currencies";
 import {
   makeCalculateCounterValue,
   makeReverseCounterValue,
-  makeGetCounterValue
+  valueFromUnit
 } from "../../helpers/countervalue";
+
+test("valueFromUnit", () => {
+  expect(valueFromUnit(1, getFiatUnit("USD"))).toBe(100);
+  expect(valueFromUnit(0.01, getCurrencyByCoinType(0).units[0])).toBe(1000000);
+})
 
 test("makeCalculateCounterValue basic test", () => {
   const getPairHistory = (ticker, fiat) => date =>
@@ -17,14 +22,15 @@ test("makeCalculateCounterValue basic test", () => {
           new Prando(`${ticker}-${fiat}`).next(0, 99);
   const calculateCounterValue = makeCalculateCounterValue(getPairHistory);
   const reverseCounterValue = makeReverseCounterValue(getPairHistory);
-  const getCounterValue = makeGetCounterValue(getPairHistory);
   const cur = getCurrencyByCoinType(1);
   const fiat = getFiatUnit("USD");
   const calc = calculateCounterValue(cur, fiat);
   const reverse = reverseCounterValue(cur, fiat);
-  const get = getCounterValue(cur, fiat);
   expect(calc(42, new Date())).toBe(
     Math.round(42 * getPairHistory(cur.units[0].code, fiat.code)(new Date()))
+  );
+  expect(calc(42, new Date(), true)).toBe(
+    42 * getPairHistory(cur.units[0].code, fiat.code)(new Date())
   );
   expect(calc(42)).toBe(42);
   // test it fallbacks on latest countervalue for an invalid date
@@ -34,6 +40,9 @@ test("makeCalculateCounterValue basic test", () => {
       42 * getPairHistory(cur.units[0].code, fiat.code)(new Date(2017, 3, 14))
     )
   );
+  expect(calc(42, new Date(2017, 3, 14), true)).toBe(
+    42 * getPairHistory(cur.units[0].code, fiat.code)(new Date(2017, 3, 14))
+  );
 
   expect(reverse(calc(42))).toBe(42);
   expect(reverse(calc(42, new Date(2017, 3, 14)), new Date(2017, 3, 14))).toBe(
@@ -42,7 +51,4 @@ test("makeCalculateCounterValue basic test", () => {
   expect(reverse(calc(42, new Date(2019, 3, 14)), new Date(2019, 3, 14))).toBe(
     42
   );
-  expect(get(new Date(2017, 10, 14))).toBe(1091.4770484628843);
-  expect(get(new Date(2019, 3, 14))).toBe(1);
-  expect(get()).toBe(1);
 });

--- a/src/helpers/countervalue.js
+++ b/src/helpers/countervalue.js
@@ -3,19 +3,22 @@
  * @flow
  */
 
+import { deprecateFunction } from "../internal";
 import type {
-  GetPairHistory,
-  GetCounterValue,
-  CalculateCounterValue
+  GetPairRate,
+  GetCounterValueRate,
+  CalculateCounterValue,
+  Unit
 } from "../types";
 
 /**
- * get the countervalue rate with a GetPairHistory.
+ * get the countervalue rate with a GetPairRate.
+ * @return a normalized cent per satoshis rate
  * @memberof helpers/countervalue
  */
-export const makeGetCounterValue = (
-  getPairHistory: GetPairHistory
-): GetCounterValue => (currency, fiatUnit) => {
+const makeGetCounterValueRate = (
+  getPairHistory: GetPairRate
+): GetCounterValueRate => (currency, fiatUnit) => {
   // FIXME we need to introduce ticker field on currency type
   const getPair = getPairHistory(currency.units[0].code, fiatUnit.code);
   // we try to pick at the date, otherwise we fallback on the "latest" countervalue
@@ -23,18 +26,21 @@ export const makeGetCounterValue = (
 };
 
 /**
- * creates a CalculateCounterValue utility with a GetPairHistory.
+ * creates a CalculateCounterValue utility with a GetPairRate.
  * This can be plugged on a redux store.
- * NB you still have to sync prices yourself. (later we might embrace future React suspense idea in GetPairHistory)
+ * NB you still have to sync prices yourself. (later we might embrace future React suspense idea in GetPairRate)
  * @memberof helpers/countervalue
  */
 export const makeCalculateCounterValue = (
-  getPairHistory: GetPairHistory
+  getPairHistory: GetPairRate
 ): CalculateCounterValue => {
-  const getCounterValue = makeGetCounterValue(getPairHistory);
+  const getCounterValueRate = makeGetCounterValueRate(getPairHistory);
   return (currency, fiatUnit) => {
-    const getRate = getCounterValue(currency, fiatUnit);
-    return (value, date) => Math.round(value * getRate(date));
+    const getRate = getCounterValueRate(currency, fiatUnit);
+    return (value, date, disableRounding) =>
+      disableRounding
+        ? value * getRate(date)
+        : Math.round(value * getRate(date));
   };
 };
 
@@ -44,15 +50,15 @@ export const makeCalculateCounterValue = (
  * @memberof helpers/countervalue
  */
 export const makeReverseCounterValue = (
-  getPairHistory: GetPairHistory
+  getPairHistory: GetPairRate
 ): CalculateCounterValue => {
-  const getCounterValue = makeGetCounterValue(getPairHistory);
+  const getCounterValueRate = makeGetCounterValueRate(getPairHistory);
   return (currency, fiatUnit) => {
-    const getRate = getCounterValue(currency, fiatUnit);
-    return (value, date) => {
+    const getRate = getCounterValueRate(currency, fiatUnit);
+    return (value, date, disableRounding) => {
       const rate = getRate(date);
       if (!rate) return 0;
-      return Math.round(value / rate);
+      return disableRounding ? value / rate : Math.round(value / rate);
     };
   };
 };
@@ -60,8 +66,33 @@ export const makeReverseCounterValue = (
 const twoDigits = (n: number) => (n > 9 ? `${n}` : `0${n}`);
 
 /**
+ * convert a value in a given unit to a normalized value
+ * For instance, for 1 BTC, valueFromUnit(1, btcUnit) returns 100000000
+ * @memberof helpers/countervalue
+ */
+export const valueFromUnit = (valueInUnit: number, unit: Unit) =>
+  valueInUnit * 10 ** unit.magnitude;
+
+/**
  * efficient implementation of YYYY-MM-DD formatter
  * @memberof helpers/countervalue
  */
 export const formatCounterValueDay = (d: Date) =>
   `${d.getFullYear()}-${twoDigits(d.getMonth() + 1)}-${twoDigits(d.getDate())}`;
+
+/**
+ * UTC version of formatCounterValueDay
+ * @memberof helpers/countervalue
+ */
+export const formatCounterValueDayUTC = (d: Date) =>
+  `${d.getUTCFullYear()}-${twoDigits(d.getUTCMonth() + 1)}-${twoDigits(
+    d.getUTCDate()
+  )}`;
+
+export const makeGetCounterValue = deprecateFunction(
+  makeGetCounterValueRate,
+  "makeGetCounterValue is deprecated. " +
+    "countervalue rate is not meant to be directly used from userland. " +
+    "If a feature is missing we add it on the wallet-common side. " +
+    "This allow us to change the rate unit in the future if needed."
+);

--- a/src/internal.js
+++ b/src/internal.js
@@ -1,0 +1,26 @@
+//@flow
+
+export function deprecateRenamedFunction(oldName: string, newF: Function) {
+  let logged = false;
+  return (...args: *) => {
+    if (!logged) {
+      logged = true;
+      console.warn(
+        `DEPRECATED: use ${newF.name} instead of ${oldName}\n`,
+        new Error().stack
+      );
+    }
+    return newF(...args);
+  };
+}
+
+export function deprecateFunction(f: Function, msg: string) {
+  let logged = false;
+  return (...args: *) => {
+    if (!logged) {
+      logged = true;
+      console.warn(`DEPRECATED: ${msg}\n`, new Error().stack);
+    }
+    return f(...args);
+  };
+}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -57,7 +57,7 @@ export type BalanceHistory = Array<{ date: Date, value: number }>;
 <any date before>    2018-03-01  2018-03-02  2018-03-03  <any date after>
 0 0 0 0 0 0 0 0 0       9.65         9.22      8.77      latest latest latest ...
  */
-export type GetPairHistory = (
+export type GetPairRate = (
   coinTicker: string,
   fiat: string
 ) => (?Date) => ?number;
@@ -66,11 +66,19 @@ export type GetPairHistory = (
  * Returns the calculated countervalue for an amount value and date
  * if date is not provided (falsy), Calc will return the "latest" countervalue
  */
-export type Calc = (value: number, date?: Date) => number;
+export type Calc = (
+  value: number,
+  date?: Date,
+  disableRounding?: boolean
+) => number;
 
+/**
+ */
 export type CalculateCounterValue = (cur: Currency, fiat: Unit) => Calc;
 
-export type GetCounterValue = (
+/**
+ */
+export type GetCounterValueRate = (
   cur: Currency,
   fiat: Unit
 ) => (date?: Date) => number;


### PR DESCRIPTION
changes of this PR should cover recent headaches found by devs on wallet-desktop & wallet-mobile. The changes are not breaking changes but some console.warn will happen with deprecation message.

- a few functions was renamed for more clarity in naming. basically using the naming "Rate" instead of "CounterValue" for most cases. to me, countervalue means a "cryptocurrency amount converted in fiat value", rate however means the current market value of 1 unit of a crypto. **rate was the appropriate meaning for most of these functions**. BTW in our case, rate is normalized to be in cents per satoshis (unlike market userfriendly that would use obvioulsy USD per BTC (8000 usd = 1 btc))
- `makeGetCounterValue` usage is deprecated and we will eventually drop the export. the idea is to not expose to outside what is inside the type "Rate". for new usecase we add it in wallet-common itself. this allows future refactoring. BTW all todays usecases should be covered via use of calculateCounterValue and reverseCounterValue.
- **calculateCounterValue and reverseCounterValue** now offers a third parameter, `disableRounding`, that if set to `true` will not do a `Math.round` ! should smoothly go in combination to https://github.com/LedgerHQ/ledgerjs/pull/131
- api/countervalue `fetchCurrentRates` fetch the latest value
- api/countervalue `fetchHistodayRates` fetch the historical values, on a daily granularity.
  - it now unifies either passing one currency object or an array of currencies
  - the returned object was not properly formatting the date on UTC time which was resulting different based on timezone (basically timezones after UTC would have the "today's" date which should not be possible because today's market price is not closed yet)
  - **experimental** (because not tested) there is a new third parameter that allow to provide a function `currency=>?day`, it returns, for a currency, the latest day (yyyy-mm-dd) that is already loaded. If this function returns the latest possible day, no API call should be done. in the future, we can imagine we could only request to our API the dates we miss to lower the required bandwidth – moreover we should only have one API call (for all currencies). the consequences of this is that the returned object is potentially a partial version of all rates. hopefully we already are doing a `merge()`
- add `valueFromUnit` utility