### PR TITLE
getPair must be a total function

### DIFF
--- a/src/__tests__/helpers/countervalue.js
+++ b/src/__tests__/helpers/countervalue.js
@@ -17,7 +17,7 @@ test("makeCalculateCounterValue basic test", () => {
     !date
       ? 1 // for the test, we make countervalue value 1 at current price
       : date > new Date()
-        ? 0
+        ? 0 // let's assume we return 0 for future
         : 0.0000001 * (Date.now() - date) +
           new Prando(`${ticker}-${fiat}`).next(0, 99);
   const calculateCounterValue = makeCalculateCounterValue(getPairHistory);
@@ -33,22 +33,21 @@ test("makeCalculateCounterValue basic test", () => {
     42 * getPairHistory(cur.ticker, fiat.ticker)(new Date())
   );
   expect(calc(42)).toBe(42);
-  // test it fallbacks on latest countervalue for an invalid date
-  expect(calc(42, new Date(2019, 1, 1))).toBe(42);
-  expect(calc(42, new Date(2017, 3, 14))).toBe(
+  expect(calc(42, new Date(2019, 1, 1))).toBe(0);
+  expect(calc(42, new Date(2017, 1, 14))).toBe(
     Math.round(
-      42 * getPairHistory(cur.ticker, fiat.ticker)(new Date(2017, 3, 14))
+      42 * getPairHistory(cur.ticker, fiat.ticker)(new Date(2017, 1, 14))
     )
   );
-  expect(calc(42, new Date(2017, 3, 14), true)).toBe(
-    42 * getPairHistory(cur.ticker, fiat.ticker)(new Date(2017, 3, 14))
+  expect(calc(42, new Date(2017, 1, 14), true)).toBe(
+    42 * getPairHistory(cur.ticker, fiat.ticker)(new Date(2017, 1, 14))
   );
 
   expect(reverse(calc(42))).toBe(42);
-  expect(reverse(calc(42, new Date(2017, 3, 14)), new Date(2017, 3, 14))).toBe(
+  expect(reverse(calc(42, new Date(2017, 1, 14)), new Date(2017, 1, 14))).toBe(
     42
   );
-  expect(reverse(calc(42, new Date(2019, 3, 14)), new Date(2019, 3, 14))).toBe(
-    42
+  expect(reverse(calc(42, new Date(2019, 1, 14)), new Date(2019, 1, 14))).toBe(
+    0
   );
 });

--- a/src/helpers/countervalue.js
+++ b/src/helpers/countervalue.js
@@ -18,11 +18,8 @@ import type {
  */
 const makeGetCounterValueRate = (
   getPairHistory: GetPairRate
-): GetCounterValueRate => (currency, fiatUnit) => {
-  const getPair = getPairHistory(currency.ticker, fiatUnit.ticker);
-  // we try to pick at the date, otherwise we fallback on the "latest" countervalue
-  return date => getPair(date) || getPair() || 0;
-};
+): GetCounterValueRate => (currency, fiatUnit) =>
+  getPairHistory(currency.ticker, fiatUnit.ticker);
 
 /**
  * creates a CalculateCounterValue utility with a GetPairRate.

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -60,7 +60,7 @@ export type BalanceHistory = Array<{ date: Date, value: number }>;
 export type GetPairRate = (
   coinTicker: string,
   fiatTicker: string
-) => (?Date) => ?number;
+) => (?Date) => number;
 
 /**
  * Returns the calculated countervalue for an amount value and date


### PR DESCRIPTION
getPair used to be designed to be a partial function, meaning it does not always have a result and the wallet-common had to do the fallback. instead, with this change, the responsability to fallback will be on user-land. it simplifies code of this lib but also allows more freedom to fallback as we want.
atm the mobile code is ready for it, but the desktop will need a slight change to not have this being a regression